### PR TITLE
Añadir servicio de fecha y vincular los servicios

### DIFF
--- a/Controllers/NasaController.cs
+++ b/Controllers/NasaController.cs
@@ -10,10 +10,14 @@ namespace PruebaDeNivelNasa.Controllers
     {
         private readonly string _url= "https://api.nasa.gov/neo/rest/v1/feed";
         private readonly INasaService _nasaService;
+        private readonly IJSONService _JSONService;
+        private readonly IDateService _dateService;
 
-        public NasaController( INasaService nasaService)
+        public NasaController( INasaService nasaService,IJSONService jSONService,IDateService dateService)
         {
             _nasaService = nasaService;
+            _JSONService = jSONService;
+            _dateService = dateService;
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,7 @@ namespace PruebaDeNivelNasa
             builder.Services.AddSwaggerGen();
             builder.Services.AddTransient<INasaService, NasaService>();
             builder.Services.AddTransient<IJSONService, JSONService>();
+            builder.Services.AddTransient<IDateService, DateService>();
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.

--- a/Services/DateService.cs
+++ b/Services/DateService.cs
@@ -1,0 +1,6 @@
+﻿namespace PruebaDeNivelNasa.Services
+{
+    public class DateService:IDateService
+    {
+    }
+}

--- a/Services/IDateService.cs
+++ b/Services/IDateService.cs
@@ -1,0 +1,6 @@
+﻿namespace PruebaDeNivelNasa.Services
+{
+    public interface IDateService
+    {
+    }
+}


### PR DESCRIPTION
Añadir el servicio de fecha para controlar las operaciones relacionadas con fechas y vincular los servicios en el controlador de nasa